### PR TITLE
fixed crash when user has local storage and group no longer exists

### DIFF
--- a/src/components/Friend.tsx
+++ b/src/components/Friend.tsx
@@ -71,16 +71,16 @@ export function FriendInfo({ friendId }: FriendProps) {
         </Center>
       </Flex>
       <Flex mt="2" mb="3">
-        <Text fontWeight="bold" fontSize="18px">
-          Eu gosto:&nbsp;
+        <Text fontSize="18px">
+          <strong>Eu gosto: </strong>
+          {like}
         </Text>
-        <Text fontSize="18px">{like}</Text>
       </Flex>
       <Flex>
-        <Text fontWeight="bold" fontSize="18px">
-          Eu não gosto:&nbsp;
+        <Text fontSize="18px">
+          <strong>Eu não gosto: </strong>
+          {dontLike}
         </Text>
-        <Text fontSize="18px">{dontLike}</Text>
       </Flex>
     </Flex>
   );

--- a/src/hooks/useGroup.ts
+++ b/src/hooks/useGroup.ts
@@ -19,9 +19,9 @@ export function useRoom(groupId: string) {
     onValue(groupRef, (group) => {
       const databaseGroup: GroupAmigoSecreto = group.val();
 
-      setGroup(databaseGroup);
-      setFriends(databaseGroup.friends || []);
-      setResult(databaseGroup.result || []);
+      setGroup(databaseGroup || { name: "Not Found" });
+      setFriends(databaseGroup?.friends || []);
+      setResult(databaseGroup?.result || []);
     });
 
     return () => {

--- a/src/pages/grupo/[group_id].tsx
+++ b/src/pages/grupo/[group_id].tsx
@@ -38,6 +38,15 @@ const Group: NextPage = () => {
       router.push("/");
     }
 
+    console.log({ group, ready: router.isReady });
+
+    if (router.isReady) {
+      if (Object.keys(group).length === 1) {
+        alert(group.name);
+        router.push("/");
+      }
+    }
+
     const found = friends.find((friend) => friend.id === user);
     if (!found && friends.length > 0) {
       alert("Invalid Session! not friend");
@@ -101,7 +110,7 @@ const Group: NextPage = () => {
   };
 
   return (
-    <Flex align="center" justify="center" flexDir="column">
+    <Flex align="center" justify="center" flexDir="column" mb="56">
       <Header />
 
       {!isDrawn && <Invite code={id} />}
@@ -147,12 +156,14 @@ const Group: NextPage = () => {
               </Button>
             )}
 
-            <FriendsList
-              friends={friends}
-              groupId={id}
-              isAdmin={isAdmin}
-              isDrawn={isDrawn}
-            />
+            {friends.length && (
+              <FriendsList
+                friends={friends}
+                groupId={id}
+                isAdmin={isAdmin}
+                isDrawn={isDrawn}
+              />
+            )}
           </>
         )}
       </Flex>

--- a/src/pages/grupo/new/[group_id].tsx
+++ b/src/pages/grupo/new/[group_id].tsx
@@ -63,7 +63,7 @@ const NewGroup: NextPage = () => {
   };
 
   return (
-    <Flex align="center" justify="center" flexDir="column">
+    <Flex align="center" justify="center" flexDir="column" mb="56">
       <Header />
       <Flex w={["95vw", "50vw"]} flexDir="column">
         <Text fontFamily="Roboto">

--- a/src/pages/grupo/user/[user_id].tsx
+++ b/src/pages/grupo/user/[user_id].tsx
@@ -63,7 +63,7 @@ export default function UserInfo() {
   };
 
   return (
-    <Flex align="center" justify="center" flexDir="column">
+    <Flex align="center" justify="center" flexDir="column" mb="56">
       <Header />
       <Flex
         w={["90vw", "50vw"]}


### PR DESCRIPTION
Group hook useGroup now returns a group with name "not found" to make easier to check if the group id from url exists. If not redirect user to home.